### PR TITLE
fix for syntax errors due to md language tags

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -143,7 +143,9 @@ export default function Home() {
       if (event.type === "event") {
         const data = event.data;
         try {
-          const text = JSON.parse(data).text ?? "";
+           let text = JSON.parse(data).text ?? "";
+          // remove "```tsx", "```typescript", "```javascript" and "```" from the generated code to avoid syntax highlighting issues
+          text = text.replace(/```(tsx|typescript|javascript)?/g, "");
           setGeneratedCode((prev) => prev + text);
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
I've used regex to manually remove them on the response side