### PR TITLE
fix for syntax errors due to md language tags

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -76,7 +76,8 @@ export default function Home() {
       if (event.type === "event") {
         const data = event.data;
         try {
-          const text = JSON.parse(data).text ?? "";
+          let text = JSON.parse(data).text ?? "";
+          text = text.replace(/```(tsx|typescript|javascript)/g, "");
           setGeneratedCode((prev) => prev + text);
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
updated regex issue and tested it on https://regex101.com

here is the final regex 
```
/```(tsx|typescript|javascript)/g
```
