### PR TITLE
Added few-shot examples to the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 ## Future Tasks
 
+- [ ] Add evals with Braintrust
 - [ ] Experiment with a prompt rewriter and launch this as well
 - [ ] Make the toast that opens better like a modal for sharability
 - [ ] Add sharability to people can take their apps and share them publicly

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 ## Future Tasks
 
 - [ ] Add evals with Braintrust
-- [ ] Checkout new models: Llama 3.2 11B and Qwen 2.5 models and see if I should add
 - [ ] Experiment with a prompt rewriter and launch this as well
 - [ ] Make the toast that opens better like a modal for sharability
 - [ ] Add sharability to people can take their apps and share them publicly

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 ## Future Tasks
 
 - [ ] Add evals with Braintrust
+- [ ] Checkout new models: Llama 3.2 11B and Qwen 2.5 models and see if I should add
 - [ ] Experiment with a prompt rewriter and launch this as well
 - [ ] Make the toast that opens better like a modal for sharability
 - [ ] Add sharability to people can take their apps and share them publicly

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -28,8 +28,8 @@ export default function Home() {
       value: "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
     },
     {
-      label: "Llama 3.1 70B",
-      value: "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+      label: "Llama 3.2 90B",
+      value: "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo",
     },
     {
       label: "Gemma 2 27B",

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -37,12 +37,12 @@ export default function Home() {
     },
   ];
   let [model, setModel] = useState(models[0].value);
-  let [shadcn, setShadcn] = useState(false);
+  let [shadcn, setShadcn] = useState(true);
   let [modification, setModification] = useState("");
   let [generatedCode, setGeneratedCode] = useState("");
   let [initialAppConfig, setInitialAppConfig] = useState({
     model: "",
-    shadcn: false,
+    shadcn: true,
   });
   let [ref, scrollTo] = useScrollTo();
   let [messages, setMessages] = useState<{ role: string; content: string }[]>(

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -32,6 +32,11 @@ export default function Home() {
       value: "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo",
     },
     {
+      label: "Qwen 2.5 72B",
+      value: "Qwen/Qwen2.5-72B-Instruct-Turbo",
+    },
+
+    {
       label: "Gemma 2 27B",
       value: "google/gemma-2-27b-it",
     },

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -35,14 +35,13 @@ export default function Home() {
       label: "Qwen 2.5 72B",
       value: "Qwen/Qwen2.5-72B-Instruct-Turbo",
     },
-
     {
       label: "Gemma 2 27B",
       value: "google/gemma-2-27b-it",
     },
   ];
   let [model, setModel] = useState(models[0].value);
-  let [shadcn, setShadcn] = useState(true);
+  let [shadcn, setShadcn] = useState(false);
   let [modification, setModification] = useState("");
   let [generatedCode, setGeneratedCode] = useState("");
   let [initialAppConfig, setInitialAppConfig] = useState({

--- a/app/api/generateCode/route.ts
+++ b/app/api/generateCode/route.ts
@@ -8,6 +8,7 @@ if (process.env.HELICONE_API_KEY) {
   options.baseURL = "https://together.helicone.ai/v1";
   options.defaultHeaders = {
     "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}`,
+    // "Helicone-Property-Local": "true",
   };
 }
 

--- a/app/api/generateCode/route.ts
+++ b/app/api/generateCode/route.ts
@@ -293,8 +293,6 @@ function getSystemPrompt(shadcn: boolean) {
       .join("\n")}
   `;
 
-  console.log(dedent(systemPrompt));
-
   return dedent(systemPrompt);
 }
 

--- a/app/api/generateCode/route.ts
+++ b/app/api/generateCode/route.ts
@@ -81,10 +81,155 @@ export async function POST(req: Request) {
   });
 }
 
+let examples = [
+  {
+    prompt: "Build a landing page for a healthcare company",
+    response: `
+    import React from 'react';
+import { Button } from "/components/ui/button"
+import { Card, CardContent } from "/components/ui/card"
+import { Heart, Shield, Clock, Users } from "lucide-react"
+
+export default function HealthcareLandingPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <header className="px-4 lg:px-6 h-14 flex items-center">
+        <a className="flex items-center justify-center" href="#">
+          <Heart className="h-6 w-6 text-primary" />
+          <span className="sr-only">HealthCare Co.</span>
+        </a>
+        <nav className="ml-auto flex gap-4 sm:gap-6">
+          <a className="text-sm font-medium hover:underline underline-offset-4" href="#">
+            Services
+          </a>
+          <a className="text-sm font-medium hover:underline underline-offset-4" href="#">
+            About
+          </a>
+          <a className="text-sm font-medium hover:underline underline-offset-4" href="#">
+            Contact
+          </a>
+        </nav>
+      </header>
+      <main className="flex-1">
+        <section className="w-full py-12 md:py-24 lg:py-32 xl:py-48">
+          <div className="container px-4 md:px-6">
+            <div className="flex flex-col items-center space-y-4 text-center">
+              <div className="space-y-2">
+                <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl lg:text-6xl/none">
+                  Your Health, Our Priority
+                </h1>
+                <p className="mx-auto max-w-[700px] text-gray-500 md:text-xl dark:text-gray-400">
+                  Providing compassionate care and cutting-edge medical solutions to improve your quality of life.
+                </p>
+              </div>
+              <div className="space-x-4">
+                <Button>Book Appointment</Button>
+                <Button variant="outline">Learn More</Button>
+              </div>
+            </div>
+          </div>
+        </section>
+        <section className="w-full py-12 md:py-24 lg:py-32 bg-gray-100 dark:bg-gray-800">
+          <div className="container px-4 md:px-6">
+            <h2 className="text-3xl font-bold tracking-tighter sm:text-5xl text-center mb-8">Our Services</h2>
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+              <Card>
+                <CardContent className="p-6 flex flex-col items-center text-center space-y-2">
+                  <Shield className="h-12 w-12 text-primary" />
+                  <h3 className="text-xl font-bold">Preventive Care</h3>
+                  <p className="text-gray-500 dark:text-gray-400">Regular check-ups and screenings to keep you healthy.</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-6 flex flex-col items-center text-center space-y-2">
+                  <Users className="h-12 w-12 text-primary" />
+                  <h3 className="text-xl font-bold">Family Medicine</h3>
+                  <p className="text-gray-500 dark:text-gray-400">Comprehensive care for patients of all ages.</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-6 flex flex-col items-center text-center space-y-2">
+                  <Clock className="h-12 w-12 text-primary" />
+                  <h3 className="text-xl font-bold">24/7 Emergency</h3>
+                  <p className="text-gray-500 dark:text-gray-400">Round-the-clock care for urgent medical needs.</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-6 flex flex-col items-center text-center space-y-2">
+                  <Heart className="h-12 w-12 text-primary" />
+                  <h3 className="text-xl font-bold">Specialized Care</h3>
+                  <p className="text-gray-500 dark:text-gray-400">Expert treatment for complex health conditions.</p>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </section>
+        <section className="w-full py-12 md:py-24 lg:py-32">
+          <div className="container px-4 md:px-6">
+            <h2 className="text-3xl font-bold tracking-tighter sm:text-5xl text-center mb-8">What Our Patients Say</h2>
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {[1, 2, 3].map((i) => (
+                <Card key={i}>
+                  <CardContent className="p-6 space-y-2">
+                    <p className="text-gray-500 dark:text-gray-400">
+                      "The care I received was exceptional. The staff was friendly and professional, and the doctors took the time to listen to my concerns."
+                    </p>
+                    <div className="flex items-center space-x-2">
+                      <img
+                        src={"/placeholder.svg?height=40&width=40"}
+                        alt="Patient"
+                        className="rounded-full"
+                        width={40}
+                        height={40}
+                      />
+                      <div>
+                        <p className="font-medium">Jane Doe</p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">Patient</p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+        </section>
+        <section className="w-full py-12 md:py-24 lg:py-32 bg-gray-100 dark:bg-gray-800">
+          <div className="container px-4 md:px-6">
+            <div className="flex flex-col items-center space-y-4 text-center">
+              <div className="space-y-2">
+                <h2 className="text-3xl font-bold tracking-tighter sm:text-5xl">Ready to Prioritize Your Health?</h2>
+                <p className="mx-auto max-w-[600px] text-gray-500 md:text-xl dark:text-gray-400">
+                  Book an appointment today and take the first step towards a healthier you.
+                </p>
+              </div>
+              <Button size="lg">Book Appointment Now</Button>
+            </div>
+          </div>
+        </section>
+      </main>
+      <footer className="flex flex-col gap-2 sm:flex-row py-6 w-full shrink-0 items-center px-4 md:px-6 border-t">
+        <p className="text-xs text-gray-500 dark:text-gray-400">© 2023 HealthCare Co. All rights reserved.</p>
+        <nav className="sm:ml-auto flex gap-4 sm:gap-6">
+          <a className="text-xs hover:underline underline-offset-4" href="#">
+            Terms of Service
+          </a>
+          <a className="text-xs hover:underline underline-offset-4" href="#">
+            Privacy
+          </a>
+        </nav>
+      </footer>
+    </div>
+  )
+}
+    `,
+  },
+];
+
 function getSystemPrompt(shadcn: boolean) {
   let systemPrompt = `
     You are an expert frontend React engineer who is also a great UI/UX designer. Follow the instructions carefully, I will tip you $1 million if you do a good job:
 
+    - Think carefully step by step.
     - Create a React component for whatever the user asked you to create and make sure it can run by itself by using a default export
     - Make sure the React app is interactive and functional by creating state when needed and having no required props
     - If you use any imports from React like useState or useEffect, make sure to import them directly
@@ -93,10 +238,10 @@ function getSystemPrompt(shadcn: boolean) {
     - Use Tailwind margin and padding classes to style the components and ensure the components are spaced out nicely
     - Please ONLY return the full React code starting with the imports, nothing else. It's very important for my job that you only return the React code with imports. DO NOT START WITH \`\`\`typescript or \`\`\`javascript or \`\`\`tsx or \`\`\`.
     - ONLY IF the user asks for a dashboard, graph or chart, the recharts library is available to be imported, e.g. \`import { LineChart, XAxis, ... } from "recharts"\` & \`<LineChart ...><XAxis dataKey="name"> ...\`. Please only use this when needed.
+    - The lucide-react library is also available to be imported ONLY FOR THE FOLLOWING ICONS: Heart, Shield, Clock, Users, Play, Home, Search, Menu, User, Settings, Mail, Bell, Calendar, Clock, Heart, Star, Upload, Download, Trash, Edit, Plus, Minus, Check, X, ArrowRight
+    - Here's an example of importing and using one: import { Heart } from "lucide-react"\` & \`<Heart className=""  />\`. PLEASE ONLY USE THE ICONS LISTED ABOVE.
+    - For placeholder images, please use a <div className="bg-gray-200 border-2 border-dashed rounded-xl w-16 h-16" />
   `;
-
-  // Removed because it causes too many errors
-  // - The lucide-react@0.263.1 library is also available to be imported. If you need an icon, use one from lucide-react. Here's an example of importing and using one: import { Camera } from "lucide-react"\` & \`<Camera color="red" size={48} />\`
 
   if (shadcn) {
     systemPrompt += `
@@ -127,6 +272,27 @@ function getSystemPrompt(shadcn: boolean) {
   systemPrompt += `
     NO OTHER LIBRARIES (e.g. zod, hookform) ARE INSTALLED OR ABLE TO BE IMPORTED.
   `;
+
+  systemPrompt += `
+    Here are some examples of a good response:
+
+    ${examples
+      .map(
+        (example) => `
+          <example>
+          <prompt>
+          ${example.prompt}
+          </prompt>
+          <response>
+          ${example.response}
+          </response>
+          </example>
+        `,
+      )
+      .join("\n")}
+  `;
+
+  console.log(dedent(systemPrompt));
 
   return dedent(systemPrompt);
 }


### PR DESCRIPTION
- Added one landing page example to the prompt
- Added Qwen 2.5 72B & Llama 3.2 90B as models to choose from
- Added the ability to do icons with lucide-react & shadcn default on
- When images are generated, use nice placeholders