### PR TITLE
feat/implemented copy code functionality in the CodeViewer component

### DIFF
--- a/components/code-viewer.tsx
+++ b/components/code-viewer.tsx
@@ -9,6 +9,8 @@ import {
 import { dracula as draculaTheme } from "@codesandbox/sandpack-themes";
 import dedent from "dedent";
 import "./code-viewer.css";
+import { useState } from "react";
+import { FiClipboard, FiCheck } from "react-icons/fi";
 
 export default function CodeViewer({
   code,
@@ -17,36 +19,60 @@ export default function CodeViewer({
   code: string;
   showEditor?: boolean;
 }) {
-  return showEditor ? (
-    <Sandpack
-      options={{
-        showNavigator: true,
-        editorHeight: "80vh",
-        showTabs: false,
-        ...sharedOptions,
-      }}
-      files={{
-        "App.tsx": code,
-        ...sharedFiles,
-      }}
-      {...sharedProps}
-    />
-  ) : (
-    <SandpackProvider
-      files={{
-        "App.tsx": code,
-        ...sharedFiles,
-      }}
-      className="flex h-full w-full grow flex-col justify-center"
-      options={{ ...sharedOptions }}
-      {...sharedProps}
-    >
-      <SandpackPreview
-        className="flex h-full w-full grow flex-col justify-center p-4 md:pt-16"
-        showOpenInCodeSandbox={false}
-        showRefreshButton={false}
-      />
-    </SandpackProvider>
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="relative">
+      {showEditor ? (
+        <Sandpack
+          options={{
+            showNavigator: true,
+            editorHeight: "80vh",
+            showTabs: false,
+            ...sharedOptions,
+          }}
+          files={{
+            "App.tsx": code,
+            ...sharedFiles,
+          }}
+          {...sharedProps}
+        />
+      ) : (
+        <SandpackProvider
+          files={{
+            "App.tsx": code,
+            ...sharedFiles,
+          }}
+          className="flex h-full w-full grow flex-col justify-center"
+          options={{ ...sharedOptions }}
+          {...sharedProps}
+        >
+          <SandpackPreview
+            className="flex h-full w-full grow flex-col justify-center p-4 md:pt-16"
+            showOpenInCodeSandbox={false}
+            showRefreshButton={false}
+          />
+        </SandpackProvider>
+      )}
+      <button 
+        onClick={handleCopy} 
+        className="absolute bottom-4 left-4 flex items-center px-2 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 transition mb-6"
+      >
+        {copied ? (
+          <FiCheck className="mr-2" />
+        ) : (
+          <FiClipboard className="mr-2" />
+        )}
+        {copied ? "Copied" : "Copy Code"}
+      </button>
+    </div>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "next-plausible": "^3.12.0",
         "react": "^18",
         "react-dom": "^18",
+        "react-icons": "^5.4.0",
         "sonner": "^1.5.0",
         "together-ai": "^0.8.0",
         "zod": "^3.23.8"
@@ -5604,6 +5605,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next-plausible": "^3.12.0",
     "react": "^18",
     "react-dom": "^18",
+    "react-icons": "^5.4.0",
     "sonner": "^1.5.0",
     "together-ai": "^0.8.0",
     "zod": "^3.23.8"


### PR DESCRIPTION
Previously -> No copy code button inside the SandBox Code Editor
![p](https://github.com/user-attachments/assets/7fc1a620-7b1a-4def-a30b-dadbdb6512a0)

Now -> Added a copy code button, that copies the generated code
![n](https://github.com/user-attachments/assets/1b820935-f57f-47c5-9312-bd5ce8730065)


Demo video:

https://github.com/user-attachments/assets/389884ca-2da0-421e-96c7-3437caf30024

