### PR TITLE
Fix generation stream reliability

### DIFF
--- a/app/(main)/chats/[id]/chat-box.tsx
+++ b/app/(main)/chats/[id]/chat-box.tsx
@@ -59,6 +59,9 @@ export default function ChatBox({
                 }),
               },
             ).then((res) => {
+              if (!res.ok) {
+                throw new Error(`Generation request failed (${res.status})`);
+              }
               if (!res.body) {
                 throw new Error("No body on response");
               }

--- a/app/(main)/chats/[id]/page.client.tsx
+++ b/app/(main)/chats/[id]/page.client.tsx
@@ -111,12 +111,82 @@ export default function PageClient({ chat }: { chat: Chat }) {
       isHandlingStreamRef.current = true;
       context.setStreamPromise(undefined);
 
-      const stream = await streamPromise;
+      const resetStream = () => {
+        isHandlingStreamRef.current = false;
+        setStreamText("");
+        setStreamPromise(undefined);
+      };
+
+      let stream: ReadableStream;
+      try {
+        stream = await streamPromise;
+      } catch {
+        resetStream();
+        return;
+      }
+
       let didPushToCode = false;
       let didPushToPreview = false;
+      let didFinalize = false;
+      let latestContent = "";
+
+      const persistResponse = (rawText: string) => {
+        if (didFinalize) return;
+        didFinalize = true;
+
+        const finalText = sanitizeAssistantOutput(rawText);
+        if (!finalText.trim()) {
+          resetStream();
+          return;
+        }
+
+        startTransition(async () => {
+          // Get all previous assistant messages with files
+          const previousAssistantMessages = chat.messages.filter(
+            (m) =>
+              m.role === "assistant" &&
+              extractAllCodeBlocks(m.content).length > 0,
+          );
+
+          // Extract files from both prior messages and the response. For an
+          // interrupted response, completed fences remain usable while an
+          // unfinished trailing fence is safely ignored.
+          const previousFiles = previousAssistantMessages.flatMap((msg) =>
+            extractAllCodeBlocks(msg.content),
+          );
+          const currentFiles = extractAllCodeBlocks(finalText);
+
+          // Merge files (current overrides previous for same paths)
+          const fileMap = new Map();
+          previousFiles.forEach((file) => fileMap.set(file.path, file));
+          currentFiles.forEach((file) => fileMap.set(file.path, file));
+          const allFiles = Array.from(fileMap.values());
+
+          const message = await createMessage(
+            chat.id,
+            finalText, // Store original AI response content (only changed files)
+            "assistant",
+            allFiles, // Store cumulative files
+          );
+
+          startTransition(() => {
+            resetStream();
+            setActiveMessage(message);
+            // When streaming finishes, switch to preview mode and keep the viewer open
+            setIsShowingCodeViewer(true);
+            setActiveTab("preview");
+            router.refresh();
+          });
+        });
+      };
+
+      const recoverPartialResponse = () => {
+        persistResponse(latestContent);
+      };
 
       ChatCompletionStream.fromReadableStream(stream)
         .on("content", (delta, content) => {
+          latestContent = content;
           setStreamText(() => sanitizeAssistantOutput(content));
 
           if (
@@ -138,49 +208,9 @@ export default function PageClient({ chat }: { chat: Chat }) {
             setIsShowingCodeViewer(true);
           }
         })
-        .on("finalContent", async (finalText) => {
-          finalText = sanitizeAssistantOutput(finalText);
-          startTransition(async () => {
-            // Get all previous assistant messages with files
-            const previousAssistantMessages = chat.messages.filter(
-              (m) =>
-                m.role === "assistant" &&
-                extractAllCodeBlocks(m.content).length > 0,
-            );
-
-            // Extract all files from previous messages
-            const previousFiles = previousAssistantMessages.flatMap((msg) =>
-              extractAllCodeBlocks(msg.content),
-            );
-
-            // Extract files from current AI response
-            const currentFiles = extractAllCodeBlocks(finalText);
-
-            // Merge files (current overrides previous for same paths)
-            const fileMap = new Map();
-            previousFiles.forEach((file) => fileMap.set(file.path, file));
-            currentFiles.forEach((file) => fileMap.set(file.path, file));
-            const allFiles = Array.from(fileMap.values());
-
-            const message = await createMessage(
-              chat.id,
-              finalText, // Store original AI response content (only changed files)
-              "assistant",
-              allFiles, // Store cumulative files
-            );
-
-            startTransition(() => {
-              isHandlingStreamRef.current = false;
-              setStreamText("");
-              setStreamPromise(undefined);
-              setActiveMessage(message);
-              // When streaming finishes, switch to preview mode and keep the viewer open
-              setIsShowingCodeViewer(true);
-              setActiveTab("preview");
-              router.refresh();
-            });
-          });
-        });
+        .on("finalContent", persistResponse)
+        .on("abort", recoverPartialResponse)
+        .on("error", recoverPartialResponse);
     }
 
     f();
@@ -231,6 +261,9 @@ export default function PageClient({ chat }: { chat: Chat }) {
             }),
           },
         ).then((res) => {
+          if (!res.ok) {
+            throw new Error(`Generation request failed (${res.status})`);
+          }
           if (!res.body) {
             throw new Error("No body on response");
           }

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -213,6 +213,9 @@ export default function Home() {
                     body: JSON.stringify({ messageId: lastMessageId, model }),
                   },
                 ).then((res) => {
+                  if (!res.ok) {
+                    throw new Error(`Generation request failed (${res.status})`);
+                  }
                   if (!res.body) {
                     throw new Error("No body on response");
                   }

--- a/app/api/get-next-completion-stream-promise/route.ts
+++ b/app/api/get-next-completion-stream-promise/route.ts
@@ -1,15 +1,17 @@
-import { PrismaClient } from "@prisma/client";
-import { PrismaNeon } from "@prisma/adapter-neon";
-import { Pool } from "@neondatabase/serverless";
 import { z } from "zod";
 import Together from "together-ai";
 import { resolveModel } from "@/lib/constants";
+import {
+  GENERATION_DEADLINE_MS,
+  superviseCompletionStream,
+} from "@/lib/completion-stream-lifecycle";
 import {
   flushBraintrustSpan,
   logBraintrustFailure,
   serializeBraintrustError,
   startBraintrustSpan,
 } from "@/lib/braintrust";
+import { getPrisma } from "@/lib/prisma";
 
 function optimizeMessagesForTokens(
   messages: { role: "system" | "user" | "assistant"; content: string }[],
@@ -43,10 +45,6 @@ const requestSchema = z.object({
 });
 
 export async function POST(req: Request) {
-  const neon = new Pool({ connectionString: process.env.DATABASE_URL });
-  const adapter = new PrismaNeon(neon);
-  const prisma = new PrismaClient({ adapter });
-
   const parsed = requestSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
     await logBraintrustFailure(
@@ -65,6 +63,7 @@ export async function POST(req: Request) {
     return new Response("Invalid request", { status: 400 });
   }
   const { messageId, model } = parsed.data;
+  const prisma = getPrisma();
 
   let message;
   try {
@@ -162,7 +161,8 @@ export async function POST(req: Request) {
   // cap mid-file on a detailed prompt, truncating the last fence — the file
   // was dropped and the preview failed with "Cannot resolve". A cap is not a
   // target, so typical generations are unaffected; only would-be truncations
-  // keep streaming (still well under the 300s maxDuration).
+  // keep streaming. The lifecycle deadline below stops unusually long runs
+  // before Vercel's hard timeout and lets the client retain completed files.
   const maxTokens = 20000;
   const inputMessages = messages.map((m) => ({
     role: m.role,
@@ -201,13 +201,16 @@ export async function POST(req: Request) {
 
   let stream: ReturnType<typeof together.chat.completions.stream>;
   try {
-    stream = together.chat.completions.stream({
-      model: resolvedModel,
-      reasoning: { enabled: false },
-      messages: inputMessages,
-      temperature,
-      max_tokens: maxTokens,
-    });
+    stream = together.chat.completions.stream(
+      {
+        model: resolvedModel,
+        reasoning: { enabled: false },
+        messages: inputMessages,
+        temperature,
+        max_tokens: maxTokens,
+      },
+      { signal: req.signal },
+    );
   } catch (error) {
     span?.log({
       error: serializeBraintrustError(error),
@@ -232,8 +235,13 @@ export async function POST(req: Request) {
     }
   });
 
-  stream
-    .finalContent()
+  let didHitGenerationDeadline = false;
+  superviseCompletionStream(stream, {
+    timeoutMs: GENERATION_DEADLINE_MS,
+    onTimeout: () => {
+      didHitGenerationDeadline = true;
+    },
+  })
     .then(async (finalText) => {
       const usage = await stream.totalUsage().catch(() => undefined);
       const completion = await stream.finalChatCompletion().catch(() => undefined);
@@ -260,6 +268,10 @@ export async function POST(req: Request) {
     .catch(async (error) => {
       span?.log({
         error: serializeBraintrustError(error),
+        metadata: {
+          generationDeadlineMs: GENERATION_DEADLINE_MS,
+          timedOut: didHitGenerationDeadline,
+        },
         metrics: {
           first_token_ms: firstTokenMs,
           total_generation_ms: performance.now() - startedAt,

--- a/lib/completion-stream-lifecycle.test.ts
+++ b/lib/completion-stream-lifecycle.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  GENERATION_DEADLINE_MS,
+  superviseCompletionStream,
+  type CompletionDeadlineClock,
+} from "./completion-stream-lifecycle";
+
+function createClock() {
+  let callback: (() => void) | undefined;
+  let cleared = false;
+  const clock: CompletionDeadlineClock = {
+    set(nextCallback) {
+      callback = nextCallback;
+      return 1;
+    },
+    clear() {
+      cleared = true;
+    },
+  };
+
+  return {
+    clock,
+    fire: () => callback?.(),
+    wasCleared: () => cleared,
+  };
+}
+
+test("the generation deadline leaves time before Vercel's hard timeout", () => {
+  assert.ok(GENERATION_DEADLINE_MS < 300_000);
+});
+
+test("a generation that never completes is aborted at the deadline", () => {
+  const testClock = createClock();
+  let aborted = false;
+
+  superviseCompletionStream(
+    {
+      abort() {
+        aborted = true;
+      },
+      finalContent() {
+        return new Promise<string>(() => {});
+      },
+    },
+    { timeoutMs: 10, clock: testClock.clock },
+  );
+
+  testClock.fire();
+  assert.equal(aborted, true);
+});
+
+test("a completed generation cannot be aborted by a stale deadline", async () => {
+  const testClock = createClock();
+  let aborted = false;
+
+  await superviseCompletionStream(
+    {
+      abort() {
+        aborted = true;
+      },
+      finalContent() {
+        return Promise.resolve("done");
+      },
+    },
+    { timeoutMs: 10, clock: testClock.clock },
+  );
+
+  testClock.fire();
+  assert.equal(testClock.wasCleared(), true);
+  assert.equal(aborted, false);
+});

--- a/lib/completion-stream-lifecycle.ts
+++ b/lib/completion-stream-lifecycle.ts
@@ -1,0 +1,45 @@
+export const GENERATION_DEADLINE_MS = 270_000;
+
+export type CompletionDeadlineClock = {
+  set(callback: () => void, delayMs: number): unknown;
+  clear(handle: unknown): void;
+};
+
+type AbortableCompletionStream<T> = {
+  abort(): void;
+  finalContent(): Promise<T>;
+};
+
+const systemClock: CompletionDeadlineClock = {
+  set(callback, delayMs) {
+    return setTimeout(callback, delayMs);
+  },
+  clear(handle) {
+    clearTimeout(handle as ReturnType<typeof setTimeout>);
+  },
+};
+
+export function superviseCompletionStream<T>(
+  stream: AbortableCompletionStream<T>,
+  {
+    timeoutMs = GENERATION_DEADLINE_MS,
+    onTimeout,
+    clock = systemClock,
+  }: {
+    timeoutMs?: number;
+    onTimeout?: () => void;
+    clock?: CompletionDeadlineClock;
+  } = {},
+): Promise<T> {
+  let settled = false;
+  const deadline = clock.set(() => {
+    if (settled) return;
+    onTimeout?.();
+    stream.abort();
+  }, timeoutMs);
+
+  return stream.finalContent().finally(() => {
+    settled = true;
+    clock.clear(deadline);
+  });
+}


### PR DESCRIPTION
## Summary

- abort long-running generation streams at 270 seconds, before Vercel’s 300-second hard timeout
- cancel the upstream Together request when the browser disconnects
- preserve usable partial output when a stream aborts or errors
- reject non-successful streaming responses and reuse the existing Prisma accessor

## Why

Production logs showed repeated 300-second runtime timeouts, instance OOM kills, and incomplete streams with a missing `finish_reason`. The previous client only persisted output after `finalContent`, so interrupted generations lost all partial work and could leave the UI stuck.

The 20k output-token ceiling remains unchanged because it was introduced to prevent known mid-file truncation. A separate lifecycle deadline now provides the runtime safety boundary.

## Verification

- `pnpm test` — 51 passed, 1 integration test skipped
- `pnpm lint` — generated preview assets and TypeScript checks passed
- deterministic regression coverage confirms stalled streams abort before the platform deadline and completed streams cannot be aborted by stale timers

## Review notes

This is intentionally a draft until the behavior is checked in a preview deployment. The change addresses the observed failure path; the OOM correlation should be monitored after deployment rather than treated as a proven single root cause.