### PR TITLE
Replace retired Kimi vision models with benchmarked Gemma 4

### DIFF
--- a/app/api/create-chat/route.ts
+++ b/app/api/create-chat/route.ts
@@ -3,7 +3,7 @@ import { getPrisma } from "@/lib/prisma";
 import { screenshotToCodePrompt } from "@/lib/prompts";
 import { buildProductionCodingPrompt } from "@/lib/prompt-config";
 import Together from "together-ai";
-import { resolveModel } from "@/lib/constants";
+import { resolveModel, SCREENSHOT_MODEL } from "@/lib/constants";
 import { createLocalChatTitle } from "@/lib/chat-title";
 import {
   flushBraintrust,
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
         try {
           const describeScreenshot = async (span?: Span) => {
             const startedAt = performance.now();
-            const screenshotModel = "moonshotai/Kimi-K2.7-Code";
+            const screenshotModel = SCREENSHOT_MODEL;
             const together = new Together();
             const screenshotUrl =
               await createValidatedImageDownloadUrl(screenshotToken);

--- a/lib/constants.test.ts
+++ b/lib/constants.test.ts
@@ -1,0 +1,21 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FALLBACK_MODEL,
+  MODELS,
+  resolveModel,
+  SCREENSHOT_MODEL,
+} from "./constants";
+
+test("retired Kimi models are migrated instead of exposed", () => {
+  assert.equal(resolveModel("moonshotai/Kimi-K2.6"), FALLBACK_MODEL);
+  assert.equal(resolveModel("moonshotai/Kimi-K2.7-Code"), FALLBACK_MODEL);
+  assert.equal(
+    MODELS.some((model) => model.value.startsWith("moonshotai/Kimi-K2.")),
+    false,
+  );
+});
+
+test("screenshot analysis uses the benchmarked Gemma replacement", () => {
+  assert.equal(SCREENSHOT_MODEL, "google/gemma-4-31B-it");
+});

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,5 @@
 export const FALLBACK_MODEL = "deepseek-ai/DeepSeek-V4-Flash-0731";
+export const SCREENSHOT_MODEL = "google/gemma-4-31B-it";
 
 // Legacy model IDs all resolve to the current fallback so existing chats/DB
 // rows never depend on retired or unreliable serverless models.
@@ -7,6 +8,7 @@ export const MODEL_ALIASES: Record<string, string> = {
   "zai-org/GLM-5": FALLBACK_MODEL,
   "zai-org/GLM-5.1": FALLBACK_MODEL,
   "moonshotai/Kimi-K2.6": FALLBACK_MODEL,
+  "moonshotai/Kimi-K2.7-Code": FALLBACK_MODEL,
   "nvidia/nemotron-3-ultra-550b-a55b": FALLBACK_MODEL,
   "Qwen/Qwen2.5-Coder-32B-Instruct": FALLBACK_MODEL,
   "MiniMaxAI/MiniMax-M2.5": FALLBACK_MODEL,
@@ -49,10 +51,6 @@ export const MODELS: ModelOption[] = [
   {
     label: "GLM 5.2",
     value: "zai-org/GLM-5.2",
-  },
-  {
-    label: "Kimi K2.7 Code",
-    value: "moonshotai/Kimi-K2.7-Code",
   },
   {
     label: "Qwen3.7 Max",

--- a/scripts/check-models.ts
+++ b/scripts/check-models.ts
@@ -11,7 +11,11 @@
 //   node --env-file=.env scripts/check-models.ts
 // (Node 23.6+ runs .ts/.mts directly via type stripping; this repo's Node is 26.)
 
-import { MODELS, resolveModel } from "../lib/constants.ts";
+import {
+  MODELS,
+  resolveModel,
+  SCREENSHOT_MODEL,
+} from "../lib/constants.ts";
 
 const API_BASE = "https://api.together.xyz/v1";
 const COMPLETIONS_URL = `${API_BASE}/chat/completions`;
@@ -228,7 +232,7 @@ async function mapLimit<T, R>(
 
 // Models the app uses internally but that are NOT on the homepage MODELS list.
 const INTERNAL_MODELS: { label: string; value: string }[] = [
-  { label: "Kimi K2.7-Code (screenshot→code)", value: "moonshotai/Kimi-K2.7-Code" },
+  { label: "Screenshot analysis", value: SCREENSHOT_MODEL },
   {
     label: "Qwen3-Coder-Next (high-quality plan)",
     value: "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",


### PR DESCRIPTION
## Summary
- use google/gemma-4-31B-it for screenshot descriptions
- remove Kimi K2.7 Code from the user-facing coding-model picker
- migrate saved Kimi K2.6/K2.7 selections to the existing DeepSeek V4 Flash coding fallback
- keep the internal model verifier aligned with the shared screenshot-model constant

## Vision benchmark
Used the production screenshot prompt against three real rendered app screenshots.

Across two passes:
- Gemma 4: 25/30 exact UI-text anchors; 15.0–17.2s median
- Kimi K2.7 Code baseline: 21/30 anchors; 4.5–4.7s median
- Qwen 3.5 9B: 20/30 anchors; 9.1–12.0s median
- Kimi K3: empty at the production 1,000-token budget; with 4,000 tokens it found 5/5 anchors but took 47.3s

Gemma is not faster, but it is the only current serverless candidate that met or exceeded K2.7 vision quality under the production request shape.

## Verification
- 51 existing tests passed; 1 skipped real-S3 test
- 2 new model-migration tests passed
- pnpm lint
- Prisma client generation plus Next production build
- authenticated exact-model inference calls

Draft for review; no deployment performed.
